### PR TITLE
Adjust autoscaling apiVersion based on k8s version

### DIFF
--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -15,7 +15,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7
+version: 0.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/common/templates/_hpa.yaml
+++ b/charts/common/templates/_hpa.yaml
@@ -1,6 +1,10 @@
 {{- define "common.hpa" -}}
 {{- if .Values.autoscaling.enabled }}
+{{- if semverCompare ">=1.23-0" .Capabilities.KubeVersion.Version }}
+apiVersion: autoscaling/v2
+{{- else -}}
 apiVersion: autoscaling/v2beta1
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "helm.name" . }}


### PR DESCRIPTION
autoscaling/v2beta1 is deprecated in k8s v1.23 and removed in version 1.26.  Adding logic to update the apiversion based on the k8s version in order to avoid problems for 1.26 users.