### PR TITLE
Standardize Probe options between each type of probe

### DIFF
--- a/charts/common/templates/_deployment.yaml
+++ b/charts/common/templates/_deployment.yaml
@@ -76,6 +76,7 @@ spec:
               path: {{ if .Values.livenessProbe -}} {{ default "/admin/health" .Values.livenessProbe.path | quote }} {{- else -}} "/admin/health" {{- end }}
               port: {{ .Values.service.containerPort }}
             periodSeconds: {{ if .Values.livenessProbe -}} {{ default 90 .Values.livenessProbe.periodSeconds }} {{- else -}} 90 {{- end }}
+            failureThreshold: {{ if .Values.livenessProbe -}} {{ default 10 .Values.livenessProbe.failureThreshold }} {{- else -}} 10 {{- end }}
             initialDelaySeconds: {{ if .Values.initialDelaySeconds -}} {{ default 5 .Values.livenessProbe.initialDelaySeconds }} {{- else -}} 5 {{- end }}
             timeoutSeconds: {{ if .Values.livenessProbe -}} {{ default 30 .Values.livenessProbe.timeoutSeconds }} {{- else -}} 30 {{- end }}
           {{- end }}
@@ -85,6 +86,7 @@ spec:
               path: {{ if .Values.readinessProbe -}} {{ default "/admin/health" .Values.readinessProbe.path | quote }} {{- else -}} "/admin/health" {{- end }}
               port: {{ .Values.service.containerPort }}
             periodSeconds: {{ if .Values.readinessProbe -}} {{ default 90 .Values.readinessProbe.periodSeconds }} {{- else -}} 90 {{- end }}
+            failureThreshold: {{ if .Values.readinessProbe -}} {{ default 10 .Values.readinessProbe.failureThreshold }} {{- else -}} 10 {{- end }}
             initialDelaySeconds: {{ if .Values.initialDelaySeconds -}} {{ default 6 .Values.livenessProbe.initialDelaySeconds }} {{- else -}} 6 {{- end }}
             timeoutSeconds: {{ if .Values.readinessProbe -}} {{ default 30 .Values.readinessProbe.timeoutSeconds }} {{- else -}} 30 {{- end }}
           {{- end }}
@@ -95,6 +97,8 @@ spec:
               port: {{ .Values.service.containerPort }}
             periodSeconds: {{ if .Values.startupProbe -}} {{ default 30 .Values.startupProbe.periodSeconds }} {{- else -}} 30 {{- end }}
             failureThreshold: {{ if .Values.startupProbe -}} {{ default 10 .Values.startupProbe.failureThreshold }} {{- else -}} 10 {{- end }}
+            initialDelaySeconds: {{ if .Values.startupProbe -}} {{ default 6 .Values.startupProbe.initialDelaySeconds }} {{- else -}} 6 {{- end }}
+            timeoutSeconds: {{ if .Values.startupProbe -}} {{ default 30 .Values.startupProbe.timeoutSeconds }} {{- else -}} 30 {{- end }}
           {{- end }}
           {{- end }}
           volumeMounts: {{- include "helm.volumeMounts" . | indent 12 }}


### PR DESCRIPTION
Give all the existing probe options already set between liveness, readiness, and startup to each of those probe types. This adds more consistency and also allows us to customize checks further.