### PR TITLE
RANCHER-970 Reason: failed to convert java.lang.String to @com.faster…

### DIFF
--- a/charts/mod-lists/values.yaml
+++ b/charts/mod-lists/values.yaml
@@ -108,7 +108,7 @@ extraEnv: |
   - name: JAVA_OPTIONS
     value: {{ .Values.javaOptions }}
   - name: MAX_LIST_SIZE
-    value: "{{ .Values.maxListSize }}"
+    value: {{ .Values.maxListSize }}
   - name: LIST_EXPORT_BATCH_SIZE
     value: "{{ .Values.listExportBatchSize }}"
   - name: spring.task.execution.pool.max-size


### PR DESCRIPTION
…xml.jackson.annotation.JsonProperty java.lang.Integer (caused by java.lang.NumberFormatException: For input string: "1.25e+06")