### PR TITLE
RANCHER-1657: point to image repos on Docker Hub

### DIFF
--- a/charts/mod-consortia-keycloak/Chart.yaml
+++ b/charts/mod-consortia-keycloak/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.11
+version: 0.0.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mod-consortia-keycloak/values.yaml
+++ b/charts/mod-consortia-keycloak/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: folioci/mod-consortia-keycloak
+  repository: folioorg/mod-consortia-keycloak
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/mod-consortia-keycloak/values.yaml
+++ b/charts/mod-consortia-keycloak/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: 732722833398.dkr.ecr.us-west-2.amazonaws.com/mod-consortia-keycloak
+  repository: folioci/mod-consortia-keycloak
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/mod-login-keycloak/Chart.yaml
+++ b/charts/mod-login-keycloak/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.10
+version: 0.0.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mod-login-keycloak/values.yaml
+++ b/charts/mod-login-keycloak/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: folioci/mod-login-keycloak
+  repository: folioorg/mod-login-keycloak
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/mod-login-keycloak/values.yaml
+++ b/charts/mod-login-keycloak/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: 732722833398.dkr.ecr.us-west-2.amazonaws.com/mod-login-keycloak
+  repository: folioci/mod-login-keycloak
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/mod-roles-keycloak/Chart.yaml
+++ b/charts/mod-roles-keycloak/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.10
+version: 0.0.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mod-roles-keycloak/values.yaml
+++ b/charts/mod-roles-keycloak/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: folioci/mod-roles-keycloak
+  repository: folioorg/mod-roles-keycloak
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/mod-roles-keycloak/values.yaml
+++ b/charts/mod-roles-keycloak/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: 732722833398.dkr.ecr.us-west-2.amazonaws.com/mod-roles-keycloak
+  repository: folioci/mod-roles-keycloak
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/mod-scheduler/Chart.yaml
+++ b/charts/mod-scheduler/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.10
+version: 0.0.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mod-scheduler/values.yaml
+++ b/charts/mod-scheduler/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: folioci/mod-scheduler
+  repository: folioorg/mod-scheduler
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"

--- a/charts/mod-scheduler/values.yaml
+++ b/charts/mod-scheduler/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: 732722833398.dkr.ecr.us-west-2.amazonaws.com/mod-scheduler
+  repository: folioci/mod-scheduler
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"

--- a/charts/mod-users-keycloak/Chart.yaml
+++ b/charts/mod-users-keycloak/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.10
+version: 0.0.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mod-users-keycloak/values.yaml
+++ b/charts/mod-users-keycloak/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: 732722833398.dkr.ecr.us-west-2.amazonaws.com/mod-users-keycloak
+  repository: folioci/mod-users-keycloak
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""

--- a/charts/mod-users-keycloak/values.yaml
+++ b/charts/mod-users-keycloak/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: folioci/mod-users-keycloak
+  repository: folioorg/mod-users-keycloak
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
Related Jira Ticket:
[RANCHER-1657: Eureka. Switch from Kitfox ECR images to the DockerHub images in *-keycloak modules in the folio-helm-v2 charts](https://folio-org.atlassian.net/browse/RANCHER-1657)