### PR TITLE
RANCHER-1654: Switch from Kitfox ECR sidecar image to the DockerHub image of the sidecar

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ helm uninstall my-release-name
 |-----------------------------------------|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
 | `eureka.enabled`                        | If `eureka.enabled` is true, Eureka related resources are created. Is disabled by default.       | `false`                                                            |
 | `eureka.sidecarContainer.name`          | Sidecar Container Identificator Name.	                                                           | `sidecar`                                                          |
-| `eureka.sidecarContainer.image`         | Sidecar Container Image Location to use for deployment.                                          | `folioci/folio-module-sidecar`                                     |
+| `eureka.sidecarContainer.image`         | Sidecar Container Image Location to use for deployment.                                          | `folioorg/folio-module-sidecar`                                     |
 | `eureka.sidecarContainer.tag`           | Sidecar Container Image Tag to be used.                                                          | `latest`                                                           |
 | `eureka.sidecarContainer.containerPort` | Sidecar Container TCP port number in the Pod to listen on.                                       | `8082`                                                             |
 | `eureka.sidecarContainer.port`          | Sidecar Container TCP port number to be exposed as a Service to outside world.                   | `8082`                                                             |

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ helm uninstall my-release-name
 |-----------------------------------------|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
 | `eureka.enabled`                        | If `eureka.enabled` is true, Eureka related resources are created. Is disabled by default.       | `false`                                                            |
 | `eureka.sidecarContainer.name`          | Sidecar Container Identificator Name.	                                                           | `sidecar`                                                          |
-| `eureka.sidecarContainer.image`         | Sidecar Container Image Location to use for deployment.                                          | `folioorg/folio-module-sidecar`                                     |
+| `eureka.sidecarContainer.image`         | Sidecar Container Image Location to use for deployment.                                          | `folioorg/folio-module-sidecar`                                    |
 | `eureka.sidecarContainer.tag`           | Sidecar Container Image Tag to be used.                                                          | `latest`                                                           |
 | `eureka.sidecarContainer.containerPort` | Sidecar Container TCP port number in the Pod to listen on.                                       | `8082`                                                             |
 | `eureka.sidecarContainer.port`          | Sidecar Container TCP port number to be exposed as a Service to outside world.                   | `8082`                                                             |

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ helm uninstall my-release-name
 |-----------------------------------------|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
 | `eureka.enabled`                        | If `eureka.enabled` is true, Eureka related resources are created. Is disabled by default.       | `false`                                                            |
 | `eureka.sidecarContainer.name`          | Sidecar Container Identificator Name.	                                                           | `sidecar`                                                          |
-| `eureka.sidecarContainer.image`         | Sidecar Container Image Location to use for deployment.                                          | `732722833398.dkr.ecr.us-west-2.amazonaws.com/folio-module-sidecar`|
+| `eureka.sidecarContainer.image`         | Sidecar Container Image Location to use for deployment.                                          | `folioci/folio-module-sidecar`                                     |
 | `eureka.sidecarContainer.tag`           | Sidecar Container Image Tag to be used.                                                          | `latest`                                                           |
 | `eureka.sidecarContainer.containerPort` | Sidecar Container TCP port number in the Pod to listen on.                                       | `8082`                                                             |
 | `eureka.sidecarContainer.port`          | Sidecar Container TCP port number to be exposed as a Service to outside world.                   | `8082`                                                             |

--- a/charts/folio-common/templates/_helpers.tpl
+++ b/charts/folio-common/templates/_helpers.tpl
@@ -206,7 +206,7 @@ Sidecar image part of container specs.
 */}}
 {{- define "folio-common.sidecar.image" -}}
 - name: {{ .Values.eureka.sidecarContainer.name | default "sidecar" }}
-  image: {{ printf "%s:%s" (.Values.eureka.sidecarContainer.image | default "732722833398.dkr.ecr.us-west-2.amazonaws.com/folio-module-sidecar") (.Values.eureka.sidecarContainer.tag | default "latest") }}
+  image: {{ printf "%s:%s" (.Values.eureka.sidecarContainer.image | default "folioci/folio-module-sidecar") (.Values.eureka.sidecarContainer.tag | default "latest") }}
   imagePullPolicy: "Always"
 {{- end }}
 

--- a/charts/folio-common/templates/_helpers.tpl
+++ b/charts/folio-common/templates/_helpers.tpl
@@ -206,7 +206,7 @@ Sidecar image part of container specs.
 */}}
 {{- define "folio-common.sidecar.image" -}}
 - name: {{ .Values.eureka.sidecarContainer.name | default "sidecar" }}
-  image: {{ printf "%s:%s" (.Values.eureka.sidecarContainer.image | default "folioci/folio-module-sidecar") (.Values.eureka.sidecarContainer.tag | default "latest") }}
+  image: {{ printf "%s:%s" (.Values.eureka.sidecarContainer.image | default "folioorg/folio-module-sidecar") (.Values.eureka.sidecarContainer.tag | default "latest") }}
   imagePullPolicy: "Always"
 {{- end }}
 

--- a/example/values.yaml
+++ b/example/values.yaml
@@ -62,7 +62,7 @@ eureka:
   enabled: false
   sidecarContainer:
       name: sidecar
-      image: 732722833398.dkr.ecr.us-west-2.amazonaws.com/folio-module-sidecar
+      image: folioci/folio-module-sidecar
       tag: latest
       containerPort: 8082
       port: 8082

--- a/example/values.yaml
+++ b/example/values.yaml
@@ -62,7 +62,7 @@ eureka:
   enabled: false
   sidecarContainer:
       name: sidecar
-      image: folioci/folio-module-sidecar
+      image: folioorg/folio-module-sidecar
       tag: latest
       containerPort: 8082
       port: 8082


### PR DESCRIPTION
[RANCHER-1654: Eureka. Switch from Kitfox ECR sidecar image to the DockerHub image of the sidecar.](https://folio-org.atlassian.net/browse/RANCHER-1654)