### PR TITLE
RANCHER-2395 Include Finc app in Eureka snapshot env

### DIFF
--- a/charts/mod-finc-config/.helmignore
+++ b/charts/mod-finc-config/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/mod-finc-config/Chart.yaml
+++ b/charts/mod-finc-config/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: mod-finc-config
+description: A Helm chart for Kubernetes mod-finc-config deployment
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 6.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "6.1.0"
+
+dependencies:
+- name: folio-common
+  version: ~0.2.0
+  repository: file://../folio-common

--- a/charts/mod-finc-config/templates/NOTES.txt
+++ b/charts/mod-finc-config/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "folio-common.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+    NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "folio-common.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "folio-common.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "folio-common.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/mod-finc-config/templates/application.yaml
+++ b/charts/mod-finc-config/templates/application.yaml
@@ -1,0 +1,41 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- include "folio-common.serviceaccount.tpl" . }}
+---
+{{- include "folio-common.deployment.tpl" . }}
+---
+{{- include "folio-common.hpa.tpl" . }}
+---
+{{- include "folio-common.service.tpl" . }}
+---
+{{- include "folio-common.ingress.tpl" . }}
+---
+{{- include "folio-common.pdb.tpl" . }}
+
+{{- range .Values.volumeClaims }}
+  {{- if and .enabled (not .existingClaim) }}
+---
+{{ include "folio-common.pvc.tpl" (list $ .) }}
+  {{- end }}
+{{- end }}
+
+{{- range $integration, $config := .Values.integrations }}
+  {{- if and $config.enabled (not $config.existingSecret) }}
+---
+{{ include "folio-common.secret" (list $ (printf "folio-common.%s.secret" $integration)) }}
+  {{- end }}
+{{- end }}
+
+{{- range $configMap, $config := .Values.configMaps }}
+  {{- if and $config.enabled (not $config.existingConfig) }}
+---
+{{ include "folio-common.configmap" (list $ (printf "folio-common.configmap.%s" $configMap)) }}
+  {{- end }}
+{{- end }}
+
+{{- if and .Values.jmx .Values.jmx.enabled }}
+---
+{{ include "folio-common.configmap" (list $ ("folio-common.configmap.jmx-config")) }}
+---
+{{ include "folio-common.configmap" (list $ ("folio-common.configmap.jmx-install")) }}
+{{- end }}

--- a/charts/mod-finc-config/values.yaml
+++ b/charts/mod-finc-config/values.yaml
@@ -1,0 +1,233 @@
+# Default values for mod-finc-config.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: folioorg/mod-finc-config
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+replicaCount: 1
+
+resources:
+  limits:
+    # cpu: 100m
+    memory: 384Mi
+  requests:
+    # cpu: 50m
+    memory: 256Mi
+
+autoscaling:
+  enabled: false
+  # minReplicas: 1
+  # maxReplicas: 4
+  # targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Should be set to NodePort if ingress for AWS ALB enabled
+service:
+  type: ClusterIP
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      containerPort: 8081
+      targetPort: http
+  annotations: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /*
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+args: []
+
+eureka:
+  enabled: false
+  envVars:
+    - name: IS_EUREKA
+      value: "true"
+  extraEnvVars: []
+    # - name: FOO
+    #   value: ba
+
+## @param javaOpts Custom JVM parameters
+##
+javaOpts: []
+
+extraJavaOpts:
+  - "-XX:MaxRAMPercentage=75.0"
+  # - "-Dlog_level=DEBUG"
+
+envVars: []
+  # - name: FOO
+  #   value: bar
+
+extraEnvVars: []
+  # - name: FOO
+  #   value: bar
+
+extraEnvVarsSecrets: []
+  # = foo-secret
+  # - bar-secret
+
+jmx:
+  enabled: false
+  agentVersion: 0.19.0
+  agentPath: /jmx_exporter
+  port: 9991
+
+heapDumpEnabled: false
+
+volumeClaims:
+  extendedtmp:
+    enabled: false
+    name: &extendedtmp_name '{{ printf "%s-%s" (include "folio-common.fullname" $) "extendedtmp" }}'
+    storageClassName: gp2
+    size: 20Gi
+    accessModes: ReadWriteOnce
+    existingClaim:
+
+extraVolumeMounts:
+  heapdump:
+    enabled: false
+    name: heapdump
+    mountPath: /tmp/dump
+  extendedtmp:
+    enabled: false
+    name: extendedtmp
+    mountPath: /tmp
+
+extraVolumes:
+  heapdump:
+    enabled: false
+    name: heapdump
+    emptyDir: {}
+  extendedtmp:
+    enabled: false
+    name: extendedtmp
+    persistentVolumeClaim:
+      claimName: *extendedtmp_name
+
+initContainer:
+  enabled: false
+  image:
+    repository: busybox
+    registry: 732722833398.dkr.ecr.us-west-2.amazonaws.com
+    tag: latest
+    pullPolicy: IfNotPresent
+  command: '["sh", "-c", "chown -R 1000:1000 /tmp"]'
+  args:
+  extraVolumeMounts:
+    extendedtmp:
+      enabled: false
+      name: extendedtmp
+      mountPath: /tmp
+
+sidecarContainers:
+  eureka:
+    enabled: '{{ .Values.eureka.enabled }}'
+    name: sidecar
+    image:
+      repository: folioorg/folio-module-sidecar
+      pullPolicy: IfNotPresent
+      tag: latest
+    envVars:
+      - '{{ include "folio-common.sidecar.env.eureka.common" . }}'
+    extraEnvVars: []
+      # - name: FOO
+      #   value: bar
+    ports:
+      - name: sidecar
+        protocol: TCP
+        port: 8082
+        containerPort: 8082
+    resources:
+      limits:
+        memory: 400Mi
+      requests:
+        memory: 200Mi
+
+integrations:
+  okapi:
+    enabled: true
+    host: okapi
+    port: 9130
+    url: http://okapi:9130
+    existingSecret: ""
+  db:
+    enabled: true
+    host: postgresql
+    hostReader: ""
+    port: 5432
+    database: folio
+    username: admin
+    password: password
+    charset: UTF-8
+    querytimeout: 60000
+    maxpoolsize: 5
+    existingSecret: ""
+
+  eureka:
+    enabled: '{{ .Values.eureka.enabled }}'
+    existingSecret: "eureka-common"
+
+configMaps:
+  log4j:
+    enabled: true
+    fileName: log4j2.xml
+    mountPath: /etc/log4j2.xml
+    existingConfig: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+pdb:
+  enabled: false
+  minAvailable: ""
+  maxUnavailable: ""
+
+startupProbe: {}
+readinessProbe: {}
+livenessProbe: {}
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Template renders:
```
install.go:224: 2025-06-19 12:22:41.80541 +0300 EEST m=+0.116919835 [debug] Original chart version: ""
install.go:241: 2025-06-19 12:22:41.806533 +0300 EEST m=+0.118042460 [debug] CHART PATH: /Users/Oleksandr_Haimanov/Workspace/git/folio/folio-org/folio-helm-v2/charts/mod-finc-config

---
# Source: mod-finc-config/templates/application.yaml
---
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: mod-finc-config
  labels:
    helm.sh/chart: mod-finc-config-6.1.0
    app.kubernetes.io/name: mod-finc-config
    app.kubernetes.io/instance: mod-finc-config
    app.kubernetes.io/version: "6.1.0"
    app.kubernetes.io/managed-by: Helm
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: mod-finc-config
      app.kubernetes.io/instance: mod-finc-config
---
# Source: mod-finc-config/templates/application.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: mod-finc-config
  labels:
    helm.sh/chart: mod-finc-config-6.1.0
    app.kubernetes.io/name: mod-finc-config
    app.kubernetes.io/instance: mod-finc-config
    app.kubernetes.io/version: "6.1.0"
    app.kubernetes.io/managed-by: Helm
---
# Source: mod-finc-config/templates/application.yaml
apiVersion: v1
data:
  log4j2.xml: ""
kind: ConfigMap
metadata:
  labels:
    app.kubernetes.io/instance: mod-finc-config
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: mod-finc-config
    app.kubernetes.io/version: 6.1.0
    helm.sh/chart: mod-finc-config-6.1.0
  name: mod-finc-config-log4j
---
# Source: mod-finc-config/templates/application.yaml
apiVersion: v1
kind: Service
metadata:
  name: mod-finc-config
  labels:
    helm.sh/chart: mod-finc-config-6.1.0
    app.kubernetes.io/name: mod-finc-config
    app.kubernetes.io/instance: mod-finc-config
    app.kubernetes.io/version: "6.1.0"
    app.kubernetes.io/managed-by: Helm
  annotations:
    {}
spec:
  type: ClusterIP
  ports:
    - name: http
      protocol: TCP
      port: 80
      targetPort: http
    - name: sidecar
      protocol: TCP
      port: 8082
      targetPort: 8082
  selector:
    app.kubernetes.io/name: mod-finc-config
    app.kubernetes.io/instance: mod-finc-config
---
# Source: mod-finc-config/templates/application.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: mod-finc-config
  labels:
    helm.sh/chart: mod-finc-config-6.1.0
    app.kubernetes.io/name: mod-finc-config
    app.kubernetes.io/instance: mod-finc-config
    app.kubernetes.io/version: "6.1.0"
    app.kubernetes.io/managed-by: Helm
spec:
  strategy:
    type: Recreate
  selector:
    matchLabels: 
      app.kubernetes.io/name: mod-finc-config
      app.kubernetes.io/instance: mod-finc-config
  template:
    metadata:
      labels: 
        app.kubernetes.io/name: mod-finc-config
        app.kubernetes.io/instance: mod-finc-config
    spec:
      serviceAccountName: mod-finc-config
      containers:
        - name: mod-finc-config
          image: "folioorg/mod-finc-config:6.1.0"
          imagePullPolicy: IfNotPresent
          env:
            - name: EZB_DOWNLOAD_URL
              value: https://ezb-api.ur.de/ezb/export/licenselist_html.php?pack=0&bibid=%s&lang=de&output_style=kbart&todo_license=ALkbart
            - name: IS_EUREKA
              value: "true"
            - name: JAVA_OPTIONS
              value: "-XX:MaxRAMPercentage=85.0 -Dlog4j.configurationFile=/etc/log4j2.xml/log4j2.xml"
          envFrom:
            - secretRef:
                name: db-credentials
            - secretRef:
                name: eureka-common
            - secretRef:
                name: okapi-credentials
          resources: 
            limits:
              memory: 384Mi
            requests:
              memory: 256Mi
          startupProbe: 
            failureThreshold: 30
            httpGet:
              path: /admin/health
              port: 8081
            initialDelaySeconds: 60
            periodSeconds: 20
            successThreshold: 1
            timeoutSeconds: 5
          ports:
            - name: http
              containerPort: 8081
              protocol: TCP
            - name: sidecar
              containerPort: 8082
              protocol: TCP
          volumeMounts:            
            - name: log4j
              mountPath: /etc/log4j2.xml/log4j2.xml
              subPath: log4j2.xml
        - name: sidecar
          image: "folioorg/folio-module-sidecar:latest"
          imagePullPolicy: IfNotPresent
          env:
          - name: AM_CLIENT_URL
            value: "http://mgr-applications"
          - name: QUARKUS_HTTP_PORT
            value: "8082"
          - name: QUARKUS_REST_CLIENT_READ_TIMEOUT
            value: "180000"
          - name: QUARKUS_REST_CLIENT_CONNECT_TIMEOUT
            value: "180000"
          - name: QUARKUS_REST_CLIENT_SEND_TIMEOUT
            value: "180000"
          - name: QUARKUS_HTTP_LIMITS_MAX_BODY_SIZE
            value: "10240K"
          - name: TE_CLIENT_URL
            value: "http://mgr-tenant-entitlements"
          - name: TM_CLIENT_URL
            value: "http://mgr-tenants"
          - name: MODULE_URL
            value: "http://localhost:8081"
          - name: MODULE_NAME
            value: "mod-finc-config"
          - name: MODULE_VERSION
            value: ""
          - name: SIDECAR_FORWARD_UNKNOWN_REQUESTS
            value: "true"
          - name: SIDECAR_URL
            value: "http://localhost:8082"
          - name: SIDECAR
            value: "true"
          - name: REQUEST_TIMEOUT
            value: "604800000"
          - name: KC_LOGIN_CLIENT_SUFFIX
            value: "-application"
          - name: KC_URI_VALIDATION_ENABLED
            value: "false"
          - name: ALLOW_CROSS_TENANT_REQUESTS
            value: "true"
          - name: QUARKUS_HTTP_LIMITS_MAX_INITIAL_LINE_LENGTH
            value: "8192"
          - name: JAVA_OPTS
            value: "-Dquarkus.log.level=INFO -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+UseZGC -Xms64m -Xmx64m -Dquarkus.log.category.'org.apache.kafka'.level=INFO"
          - name: SC_LOG_LEVEL
            value: "INFO"
          - name: ROOT_LOG_LEVEL
            value: "INFO"
          - name: SECRET_STORE_TYPE
            valueFrom:
              secretKeyRef:
                name: eureka-common
                key: SECRET_STORE_TYPE
          - name: SECRET_STORE_AWS_SSM_REGION
            valueFrom:
              secretKeyRef:
                name: eureka-common
                key: SECRET_STORE_AWS_SSM_REGION
          - name: ENV
            valueFrom:
              secretKeyRef:
                name: db-credentials
                key: ENV
          - name: SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION
            valueFrom:
              secretKeyRef:
                name: eureka-common
                key: SIDECAR_FORWARD_UNKNOWN_REQUESTS_DESTINATION
          - name: KAFKA_HOST
            valueFrom:
              secretKeyRef:
                name: kafka-credentials
                key: KAFKA_HOST
          - name: KAFKA_PORT
            valueFrom:
              secretKeyRef:
                name: kafka-credentials
                key: KAFKA_PORT
          - name: MOD_USERS_KEYCLOAK_URL
            valueFrom:
              secretKeyRef:
                name: eureka-common
                key: MOD_USERS_KEYCLOAK_URL
          - name: MOD_USERS_BL
            valueFrom:
              secretKeyRef:
                name: eureka-common
                key: MOD_USERS_BL
          - name: KC_URL
            valueFrom:
              secretKeyRef:
                name: eureka-common
                key: KC_URL
          - name: JAVA_OPTS
            value: -Dquarkus.log.level=DEBUG -Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:+UseZGC -Xms160m -Xmx160m -Dquarkus.log.category.'org.apache.kafka'.level=DEBUG
          resources: 
            limits:
              memory: 400Mi
            requests:
              memory: 290Mi
      volumes:        
        - name: log4j
          configMap:
            name: mod-finc-config-log4j
            defaultMode: 0755
---
# Source: mod-finc-config/templates/application.yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: mod-finc-config
  labels:
    helm.sh/chart: mod-finc-config-6.1.0
    app.kubernetes.io/name: mod-finc-config
    app.kubernetes.io/instance: mod-finc-config
    app.kubernetes.io/version: "6.1.0"
    app.kubernetes.io/managed-by: Helm
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: mod-finc-config
  minReplicas: 1
  maxReplicas: 2
  metrics:
    - type: Resource
      resource:
        name: memory
        target:
          type: Utilization
          averageUtilization: 75
```