### PR TITLE
[bugfix] _sidecar.tpl fails on multiple .sidecar.extraEnvVars

### DIFF
--- a/charts/folio-common/Chart.yaml
+++ b/charts/folio-common/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 name: folio-common
 description: A common Helm chart for FOLIO Kubernetes charts
 # NOTE! Versions always should be the same
-version: 0.2.26
-appVersion: 0.2.26
+version: 0.2.27
+appVersion: 0.2.27
 
 
 home: https://folio.org/

--- a/charts/folio-common/templates/_sidecar.tpl
+++ b/charts/folio-common/templates/_sidecar.tpl
@@ -23,7 +23,7 @@
   - name: {{ .name }}
     value: {{ .value | quote }}
   {{- else }}
-  - {{- typeIs "string" . | ternary . (toYaml .) | indent 2 }}
+  {{- typeIs "string" . | ternary . (toYaml (list .)) | nindent 2 }}
   {{- end }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
Having more than `.sidecar.extraEnvVars` causes helm templating to fail.
This is due to  indentation mismatch between the first item and the rest.